### PR TITLE
feat: add twitch-exporter Helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,4 @@ helm install speedtest-exporter damoun/speedtest-exporter
 * `damoun/proxmox-exporter`: Chart for Prometheus [Proxmox exporter](https://github.com/prometheus-pve/prometheus-pve-exporter).
 * `damoun/speedtest-exporter`: Chart for Prometheus [Speedtest exporter](https://github.com/danopstech/speedtest_exporter).
 * `damoun/cloudflared`: Chart for [Cloudflared](https://github.com/cloudflare/cloudflared).
+* `damoun/twitch-exporter`: Chart for Prometheus [Twitch exporter](https://github.com/damoun/twitch_exporter).

--- a/charts/twitch-exporter/.helmignore
+++ b/charts/twitch-exporter/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/twitch-exporter/Chart.yaml
+++ b/charts/twitch-exporter/Chart.yaml
@@ -1,0 +1,7 @@
+apiVersion: v2
+name: twitch-exporter
+description: A Helm chart for twitch_exporter
+type: application
+
+version: 0.1.0
+appVersion: "1.0.5"

--- a/charts/twitch-exporter/templates/NOTES.txt
+++ b/charts/twitch-exporter/templates/NOTES.txt
@@ -1,0 +1,22 @@
+1. Get the application URL by running these commands:
+{{- if .Values.ingress.enabled }}
+{{- range $host := .Values.ingress.hosts }}
+  {{- range .paths }}
+  http{{ if $.Values.ingress.tls }}s{{ end }}://{{ $host.host }}{{ .path }}
+  {{- end }}
+{{- end }}
+{{- else if contains "NodePort" .Values.service.type }}
+  export NODE_PORT=$(kubectl get --namespace {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" services {{ include "twitch_exporter.fullname" . }})
+  export NODE_IP=$(kubectl get nodes --namespace {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
+  echo http://$NODE_IP:$NODE_PORT
+{{- else if contains "LoadBalancer" .Values.service.type }}
+     NOTE: It may take a few minutes for the LoadBalancer IP to be available.
+           You can watch its status by running 'kubectl get --namespace {{ .Release.Namespace }} svc -w {{ include "twitch_exporter.fullname" . }}'
+  export SERVICE_IP=$(kubectl get svc --namespace {{ .Release.Namespace }} {{ include "twitch_exporter.fullname" . }} --template "{{"{{ range (index .status.loadBalancer.ingress 0) }}{{.}}{{ end }}"}}")
+  echo http://$SERVICE_IP:{{ .Values.service.port }}
+{{- else if contains "ClusterIP" .Values.service.type }}
+  export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "twitch_exporter.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+  export CONTAINER_PORT=$(kubectl get pod --namespace {{ .Release.Namespace }} $POD_NAME -o jsonpath="{.spec.containers[0].ports[0].containerPort}")
+  echo "Visit http://127.0.0.1:8080 to use your application"
+  kubectl --namespace {{ .Release.Namespace }} port-forward $POD_NAME 8080:$CONTAINER_PORT
+{{- end }}

--- a/charts/twitch-exporter/templates/_helpers.tpl
+++ b/charts/twitch-exporter/templates/_helpers.tpl
@@ -1,0 +1,51 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "twitch_exporter.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "twitch_exporter.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "twitch_exporter.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "twitch_exporter.labels" -}}
+helm.sh/chart: {{ include "twitch_exporter.chart" . }}
+{{ include "twitch_exporter.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "twitch_exporter.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "twitch_exporter.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}

--- a/charts/twitch-exporter/templates/deployment.yaml
+++ b/charts/twitch-exporter/templates/deployment.yaml
@@ -1,0 +1,79 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "twitch_exporter.fullname" . }}
+  labels:
+    {{- include "twitch_exporter.labels" . | nindent 4 }}
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "twitch_exporter.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "twitch_exporter.labels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+    spec:
+      {{ if .Values.image.pullSecrets }}
+      imagePullSecrets:
+        {{- toYaml .Values.image.pullSecrets | nindent 12 }}
+      {{- end }}
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+
+          args: [
+            {{- if .Values.twitch.accessToken }}
+            # access token is provided as a secret
+            "--twitch.access-token=$(TWITCH_ACCESS_TOKEN)",
+            {{ end -}}
+
+            {{- if .Values.twitch.refreshToken }}
+            # refresh token is provided as a secret
+            "--twitch.refresh-token=$(TWITCH_REFRESH_TOKEN)",
+            {{ end -}}
+
+            {{- if .Values.twitch.clientId }}
+            "--twitch.client-id=$(TWITCH_CLIENT_ID)",
+            {{ end -}}
+
+            {{- if .Values.twitch.clientSecret }}
+            # client secret is provided as a secret
+            "--twitch.client-secret=$(TWITCH_CLIENT_SECRET)",
+            {{ end -}}
+
+            {{- range .Values.twitch.channels }}
+            "--twitch.channel={{ . }}",
+            {{ end -}}
+
+            {{- if .Values.twitch.eventsub.enabled }}
+            "--eventsub.enabled",
+            "--eventsub.webhook-url=$(EVENTSUB_WEBHOOK_URL)",
+            "--eventsub.webhook-secret=$(EVENTSUB_WEBHOOK_SECRET)",
+            {{ end -}}
+
+            {{- range .Values.twitch.additionalParameters }}
+            "{{ . }}",
+            {{ end -}}
+          ]
+          envFrom:
+            - secretRef:
+                name: twitch-exporter-env
+          ports:
+            - containerPort: {{ .Values.service.port }}
+          livenessProbe:
+            httpGet:
+              path: /
+              port: {{ .Values.service.port }}
+          {{- with .Values.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}

--- a/charts/twitch-exporter/templates/ingress.yaml
+++ b/charts/twitch-exporter/templates/ingress.yaml
@@ -1,0 +1,23 @@
+{{- if .Values.ingress.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "twitch_exporter.fullname" . }}
+  labels:
+    {{- include "twitch_exporter.labels" . | nindent 4 }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    - http:
+        paths:
+          - path: /eventsub
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "twitch_exporter.fullname" . }}
+                port:
+                  number: {{ .Values.service.port }}
+{{- end }}

--- a/charts/twitch-exporter/templates/secrets.yaml
+++ b/charts/twitch-exporter/templates/secrets.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: twitch-exporter-env
+type: Opaque
+stringData:
+  TWITCH_ACCESS_TOKEN: "{{ .Values.twitch.accessToken }}"
+  TWITCH_REFRESH_TOKEN: "{{ .Values.twitch.refreshToken }}"
+
+  TWITCH_CLIENT_ID: "{{ .Values.twitch.clientId }}"
+  TWITCH_CLIENT_SECRET: "{{ .Values.twitch.clientSecret }}"
+
+  EVENTSUB_WEBHOOK_URL: "{{ .Values.twitch.eventsub.webhookURL }}"
+  EVENTSUB_WEBHOOK_SECRET: "{{ .Values.twitch.eventsub.webhookSecret }}"

--- a/charts/twitch-exporter/templates/service.yaml
+++ b/charts/twitch-exporter/templates/service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "twitch_exporter.fullname" . }}
+  labels:
+    {{- include "twitch_exporter.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: {{ .Values.service.port }}
+  selector:
+    {{- include "twitch_exporter.selectorLabels" . | nindent 4 }}

--- a/charts/twitch-exporter/values.yaml
+++ b/charts/twitch-exporter/values.yaml
@@ -1,0 +1,58 @@
+twitch:
+  # client-id is required at all times
+  clientId: ""
+
+  # client secret is preferred for use without private data, as it uses no oauth
+  # flow to grant access to the API. Endpoints such as sub counts are not with
+  # this method.
+  #
+  # if both client-secret and access-token are provided, client-secret will be
+  # used.
+  clientSecret: ""
+
+  # access-token & refresh-token are required for use with private data, such
+  # as sub counts.
+  accessToken: ""
+  refreshToken: ""
+
+  # channels is a list of channels to export metrics for.
+  channels:
+    - jordofthenorth
+    - timthetatman
+    - dam0un
+    - surdaft
+
+  # eventsub is disabled due to the need to expose the service
+  eventsub:
+    enabled: false
+    webhookURL: ""
+    webhookSecret: ""
+
+  # additionalParameters is a list of additional parameters to pass to the
+  # exporter, such as --collector.channel_chat_messages_total
+  additionalParameters: []
+
+image:
+  repository: damoun/twitch-exporter
+  pullPolicy: Always
+  tag: "latest"
+  pullSecrets: []
+
+serviceAccount:
+  create: true
+  automount: true
+
+service:
+  type: ClusterIP
+  port: 9184
+
+# ingress would be required if using eventsub
+ingress:
+  enabled: false
+  annotations: {}
+
+resources: {}
+
+podLabels: {}
+
+podAnnotations: {}


### PR DESCRIPTION
## Summary

- Copies the `twitch-exporter` Helm chart from `damoun/twitch_exporter` into this repository
- Adds `damoun/twitch-exporter` entry to `README.md` chart sources