### PR TITLE
Add twitch-exporter chart to charts.damoun.dev index

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -57,3 +57,17 @@ jobs:
           config: cr.yaml
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Merge twitch-exporter chart index
+        run: |
+          git checkout gh-pages
+          curl -sL -o /tmp/twitch-exporter-index.yaml \
+            https://damoun.github.io/twitch_exporter/index.yaml
+          yq eval-all '
+            select(fileIndex == 0).entries["twitch-exporter"] = select(fileIndex == 1).entries["twitch-exporter"]
+            | select(fileIndex == 0)
+          ' index.yaml /tmp/twitch-exporter-index.yaml > /tmp/merged-index.yaml
+          mv /tmp/merged-index.yaml index.yaml
+          git add index.yaml
+          git diff --staged --quiet || git commit -m "Merge twitch-exporter chart from damoun/twitch_exporter"
+          git push origin gh-pages


### PR DESCRIPTION
## Summary
- Merges the twitch-exporter Helm chart entries from `damoun/twitch_exporter` GitHub Pages into the `gh-pages` index after chart-releaser runs
- Makes the chart discoverable via `helm repo add damoun https://charts.damoun.dev` without duplicating chart source files in this repo
- Chart source and releases remain in [damoun/twitch_exporter](https://github.com/damoun/twitch_exporter)

## How it works
A new workflow step runs after chart-releaser:
1. Checks out `gh-pages`
2. Fetches the external index from `https://damoun.github.io/twitch_exporter/index.yaml`
3. Merges `twitch-exporter` entries into the local `index.yaml` using `yq`
4. Commits and pushes only if there are changes

Chart-releaser's `--merge` behavior preserves externally-added entries on subsequent runs.

## Test plan
- [ ] Verify workflow runs successfully on push to main
- [ ] Check `gh-pages` `index.yaml` contains `twitch-exporter` entries
- [ ] `helm repo update && helm search repo damoun/twitch-exporter` returns results